### PR TITLE
Remove use of istextfile

### DIFF
--- a/mload.py
+++ b/mload.py
@@ -122,12 +122,6 @@ def loadFile(filename, target, solver="gsl", merge=True):
         newTarget = target + "-" + str(num)
         num = num + 1
     target = newTarget
-    istext = True
-    with open(filename, 'rb') as infile:
-        istext = mtypes.istextfile(infile)
-    if not istext:
-        print 'Cannot handle any binary formats yet'
-        return None
     parent, child = posixpath.split(target)
     p = moose.Neutral(parent)
     if not merge and p.path != '/':


### PR DESCRIPTION
The check didn't deliver a definite answer anyway. If the file has
wrong format, an error will be thrown by the code that tries to load
it anyway, so there's no need to check if the file is binary
beforehand.

Follow-up for https://github.com/BhallaLab/moose-core/pull/71.