### PR TITLE
Update kkitOrdinateUtil.py

### DIFF
--- a/plugins/kkitOrdinateUtil.py
+++ b/plugins/kkitOrdinateUtil.py
@@ -16,6 +16,7 @@ Oct 18: moved some function to kkitUtil
 getxyCord, etc function are added
 '''
 import collections
+import moose
 from moose import *
 import numpy as np
 from moose import wildcardFind,element,PoolBase,CplxEnzBase,Annotator,exists
@@ -25,7 +26,6 @@ import networkx as nx
 from kkitUtil import getRandColor,colorCheck,findCompartment, findGroup, findGroup_compt, mooseIsInstance
 from PyQt4.QtGui import QColor
 import re
-import moose._moose as moose
 
 def getxyCord(xcord,ycord,list1):
     for item in list1:


### PR DESCRIPTION
`_moose` should not be imported directly. All functions gui needs should come from either `moose` or other python files. Never directly from cpp extenstion. `__init__.py` takes care that all functions are available under namespace moose. `_moose.so` might change to `_moose.so` if WIndows build PR (https://github.com/BhallaLab/moose-core/pull/373) is merged.